### PR TITLE
Update upload-pages-artifact versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,10 +45,10 @@ jobs:
       uses: actions/configure-pages@v3
 
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@v1
+      uses: actions/upload-pages-artifact@v3
       with:
         path: './_build/html'
 
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v1
+      uses: actions/deploy-pages@v4


### PR DESCRIPTION
Update version stuff in the GitHub Pages config so that the site properly builds after a dependency was deprecated.

For more info, see below:
https://github.com/jupyter-book/jupyter-book/pull/2318/files