### PR TITLE
Update GitHub Actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,18 +24,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
       with:
         python-version: '3.x'
+        cache: 'pip'
 
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        pip install jupyter-book
+        pip install -r requirements.txt
 
     - name: Build Jupyter Book HTML
       run: |


### PR DESCRIPTION
- Removed an unnecessary second check for installing `jupyter-book` (based on the logs, it looks like this didn't accidentally install Jupyter Book 2.0 like I had feared, but we might as well implement this for simplicity)
- Update versions of `checkout` and `setup-python` GitHub Actions, which should help improve build performance
- Enabled `pip` caching, which should significantly reduce build times and network usage