### PR TITLE
Update more GitHub Action versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,10 +42,10 @@ jobs:
         jupyter-book build .
 
     - name: Setup Pages
-      uses: actions/configure-pages@v3
+      uses: actions/configure-pages@v5
 
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-pages-artifact@v4
       with:
         path: './_build/html'
 


### PR DESCRIPTION
Updated the versions of `configure-pages` and `upload-page-artifact`. I've been trying to figure out why the action isn't running automatically on merge like it used to, but I have no idea at this point.